### PR TITLE
Use service for client instead of ingress to prevent tls issues

### DIFF
--- a/roles/grafana/templates/grafana.j2
+++ b/roles/grafana/templates/grafana.j2
@@ -21,7 +21,7 @@ spec:
       - configMapRef:
           name: grafana-plugins
   client:
-    preferIngress: true
+    preferIngress: false
   route:
     spec:
       enabled: "True"


### PR DESCRIPTION
Tested with grafana-operator 5.15.1
https://github.com/redhat-performance/odf-grafana/issues/28

This was both a w/a for the ingress TLS cert issue, and a response to the below grafana-operator PR added in 5.15.0 which noted the internal service address was missing the `.svc` . If all the resources are internal, no need to use the `preferIngress: true`. If one wishes to use the `preferIngress: true` for whatever reason, then it would require setting up the certs for the route domain.

https://github.com/grafana/grafana-operator/pull/1713