### PR TITLE
Set CPU/Memory/Timeouts for large queries, adjust dashboard datasources

### DIFF
--- a/roles/dashboard/tasks/load_dashboard.yml
+++ b/roles/dashboard/tasks/load_dashboard.yml
@@ -8,7 +8,7 @@
 # dealing with a dict.
 - name: Load dashboard definition
   set_fact: 
-    dashboard_content: "'{{ lookup('file', item) }}'"
+    dashboard_content: "'{{ lookup('file', item) | replace('${datasource}', hostvars['localhost']['prometheus_datasource_uid'])}}'"
   when: not deploy_local
 
 - name: Define dashboard to Grafana

--- a/roles/datasource/tasks/main.yml
+++ b/roles/datasource/tasks/main.yml
@@ -56,6 +56,16 @@
     cmd: oc apply -f -
     stdin: "{{ lookup('template', 'prometheus_datasource.j2') }}"
 
+
+- name: Get Prometheus DataSource UID
+  command:
+    cmd: oc get -n {{ grafana_namespace }} grafanadatasource prometheus -ojsonpath="{.metadata.uid}"
+  register: prometheus_datasource
+
+- name: Set Prometheus DataSource UID as fact
+  set_fact:
+    prometheus_datasource_uid: "{{ prometheus_datasource.stdout }}"
+
 - name: Add Infinity datasource to Grafana
   command:
     cmd: oc apply -f -

--- a/roles/datasource/templates/prometheus_datasource.j2
+++ b/roles/datasource/templates/prometheus_datasource.j2
@@ -4,6 +4,7 @@ kind: GrafanaDatasource
 metadata:
   name: prometheus
   namespace: {{ grafana_namespace }}
+  annotations:
 spec:
   name: {{ prometheus_datasource_name }}.yml
   datasource:
@@ -18,6 +19,7 @@ spec:
       tlsSkipVerify: true
       timeInterval: "10s"
       httpHeaderName1: 'Authorization'
+      timeout: '{{ datasource_http_timeout }}'
     secureJsonData:
       httpHeaderValue1: 'Bearer {{ token }}'
   instanceSelector:

--- a/roles/grafana/defaults/main.yml
+++ b/roles/grafana/defaults/main.yml
@@ -3,4 +3,8 @@ grafana_user: grafana
 grafana_image_tag: 11.1.0
 grafana_cpu_requests: 500m
 grafana_mem_requests: 1Gi
-
+grafana_mem_limits: 8Gi
+grafana_route_timeout: "300"
+dataproxy_timeout: "300"
+dataproxy_keep_alive_seconds: "300"
+datasource_http_timeout: "300"

--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -28,6 +28,10 @@
     route_json: "{{ route.stdout|from_json}}"
   when: not deploy_local and route.rc == 0
 
+- name: Annotate the Grafana route to set timeout
+  command:
+    cmd: oc -n {{ grafana_namespace }} annotate route/grafana-route --overwrite haproxy.router.openshift.io/timeout={{ grafana_route_timeout }}s
+
 - name: Set the Grafana route URL
   set_fact:
     grafana_route: "https://{{ route_json.spec.host }}"

--- a/roles/grafana/templates/grafana.j2
+++ b/roles/grafana/templates/grafana.j2
@@ -20,6 +20,17 @@ spec:
     envFrom:
       - configMapRef:
           name: grafana-plugins
+    spec:
+      template:
+        spec:
+          containers:
+            - name: grafana
+              resources:
+                limits:
+                  memory: {{ grafana_mem_limits }}
+                requests:
+                  cpu: {{ grafana_cpu_requests }}
+                  memory: {{ grafana_mem_requests }}
   client:
     preferIngress: false
   route:
@@ -41,6 +52,9 @@ spec:
     security:
       admin_user: {{ grafana_user }}
       admin_password: {{ grafana_password }}
+    dataproxy:
+      timeout: "'{{ dataproxy_timeout }}'"
+      keep_alive_seconds: "'{{ dataproxy_keep_alive_seconds }}'"
   service:
     name: "grafana-service"
     labels:
@@ -49,8 +63,3 @@ spec:
   dashboardLabelSelector:
     - matchExpressions:
         - { key: app, operator: In, values: [grafana] }
-  resources:
-    # Optionally specify container resources
-    requests:
-      cpu: {{ grafana_cpu_requests }}
-      memory: {{ grafana_mem_requests }}


### PR DESCRIPTION
I have some rather large queries at times which can take over the 30s default and requires more CPU.
- Allow increased timeouts (default to 300s)
- Update CPU/Memory requests/limits spec (lmk if limits is not desired)
- Update dashboard datasource uid `${datasource}` at time of creation with DataSource `.metadata.uid`