### PR TITLE
Removed exported_instance in prom query and updated with instance

### DIFF
--- a/roles/dashboard/files/odf-performance-analysis.json
+++ b/roles/dashboard/files/odf-performance-analysis.json
@@ -221,7 +221,7 @@
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "count(count by(exported_instance) (ceph_disk_occupation))",
+              "expr": "count(count by(instance) (ceph_disk_occupation))",
               "format": "table",
               "instant": true,
               "interval": "",
@@ -3726,7 +3726,7 @@
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum by(instance) (rate(node_disk_writes_completed_total[1m]) * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation, \"instance\", \"$1\", \"exported_instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\")) + sum by(instance) (rate(node_disk_reads_completed_total[1m]) * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation, \"instance\", \"$1\", \"exported_instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\"))",
+              "expr": "sum by(instance) (rate(node_disk_writes_completed_total[1m]) * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation, \"instance\", \"$1\", \"instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\")) + sum by(instance) (rate(node_disk_reads_completed_total[1m]) * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation, \"instance\", \"$1\", \"instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\"))",
               "legendFormat": "{{instance}}",
               "range": true,
               "refId": "A"
@@ -3816,7 +3816,7 @@
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum by(instance) (rate(node_disk_written_bytes_total[1m]) * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation, \"instance\", \"$1\", \"exported_instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\")) + sum by(instance) (rate(node_disk_read_bytes_total[1m]) * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation, \"instance\", \"$1\", \"exported_instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\"))",
+              "expr": "sum by(instance) (rate(node_disk_written_bytes_total[1m]) * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation, \"instance\", \"$1\", \"instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\")) + sum by(instance) (rate(node_disk_read_bytes_total[1m]) * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation, \"instance\", \"$1\", \"instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\"))",
               "legendFormat": "{{instance}}",
               "range": true,
               "refId": "A"
@@ -3910,7 +3910,7 @@
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "rate(node_disk_writes_completed_total[1m]) * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation, \"instance\", \"$1\", \"exported_instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\")",
+              "expr": "rate(node_disk_writes_completed_total[1m]) * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation, \"instance\", \"$1\", \"instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\")",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -3923,7 +3923,7 @@
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "sum(rate(node_disk_writes_completed_total[1m]) * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation, \"instance\", \"$1\", \"exported_instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\"))",
+              "expr": "sum(rate(node_disk_writes_completed_total[1m]) * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation, \"instance\", \"$1\", \"instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\"))",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -4015,7 +4015,7 @@
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "(rate(node_disk_write_time_seconds_total[1m]) / clamp_min(rate(node_disk_writes_completed_total[1m]),1)) * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation, \"instance\", \"$1\", \"exported_instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\")",
+              "expr": "(rate(node_disk_write_time_seconds_total[1m]) / clamp_min(rate(node_disk_writes_completed_total[1m]),1)) * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation, \"instance\", \"$1\", \"instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\")",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -4137,7 +4137,7 @@
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "rate(node_disk_written_bytes_total[1m]) * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation, \"instance\", \"$1\", \"exported_instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\")",
+              "expr": "rate(node_disk_written_bytes_total[1m]) * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation, \"instance\", \"$1\", \"instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\")",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -4151,7 +4151,7 @@
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "sum(rate(node_disk_written_bytes_total[1m]) * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation, \"instance\", \"$1\", \"exported_instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\"))",
+              "expr": "sum(rate(node_disk_written_bytes_total[1m]) * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation, \"instance\", \"$1\", \"instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\"))",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -4243,7 +4243,7 @@
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "(rate(node_disk_written_bytes_total[30s]) / rate(node_disk_writes_completed_total[30s]) ) * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation, \"instance\", \"$1\", \"exported_instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\")",
+              "expr": "(rate(node_disk_written_bytes_total[30s]) / rate(node_disk_writes_completed_total[30s]) ) * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation, \"instance\", \"$1\", \"instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\")",
               "legendFormat": "{{ceph_daemon}}/{{device}}",
               "range": true,
               "refId": "A"
@@ -4314,7 +4314,7 @@
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "rate(node_disk_reads_completed_total[1m]) * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation, \"instance\", \"$1\", \"exported_instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\")",
+              "expr": "rate(node_disk_reads_completed_total[1m]) * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation, \"instance\", \"$1\", \"instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\")",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -4327,7 +4327,7 @@
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "sum(rate(node_disk_reads_completed_total[1m]) * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation, \"instance\", \"$1\", \"exported_instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\"))",
+              "expr": "sum(rate(node_disk_reads_completed_total[1m]) * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation, \"instance\", \"$1\", \"instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\"))",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -4421,7 +4421,7 @@
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "(rate(node_disk_read_time_seconds_total[1m]) / clamp_min(rate(node_disk_reads_completed_total[1m]),1)) * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation, \"instance\", \"$1\", \"exported_instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\")",
+              "expr": "(rate(node_disk_read_time_seconds_total[1m]) / clamp_min(rate(node_disk_reads_completed_total[1m]),1)) * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation, \"instance\", \"$1\", \"instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\")",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -4543,7 +4543,7 @@
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "rate(node_disk_read_bytes_total[1m]) * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation, \"instance\", \"$1\", \"exported_instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\")",
+              "expr": "rate(node_disk_read_bytes_total[1m]) * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation, \"instance\", \"$1\", \"instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\")",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -4557,7 +4557,7 @@
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "sum(rate(node_disk_read_bytes_total[1m]) * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation, \"instance\", \"$1\", \"exported_instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\"))",
+              "expr": "sum(rate(node_disk_read_bytes_total[1m]) * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation, \"instance\", \"$1\", \"instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\"))",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -4651,7 +4651,7 @@
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "(rate(node_disk_read_bytes_total[30s]) / rate(node_disk_reads_completed_total[30s]) ) * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation, \"instance\", \"$1\", \"exported_instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\")",
+              "expr": "(rate(node_disk_read_bytes_total[30s]) / rate(node_disk_reads_completed_total[30s]) ) * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation, \"instance\", \"$1\", \"instance\", \"(.*)\"), \"device\", \"$1\", \"device\", \"/dev/(.*)\")",
               "legendFormat": "{{ceph_daemon}}/{{device}}",
               "range": true,
               "refId": "A"


### PR DESCRIPTION
Updated exported_instance usage in prom queries and replaced with instance.
This is causing issues, grafana chart is not loading with exported_instance usage.
Problem observed with Cloud(IBM Cloud, aws, azure) deployments and BM deployments.